### PR TITLE
add bgpnetwork functions

### DIFF
--- a/fortios/sdkcore/sdkfos.go
+++ b/fortios/sdkcore/sdkfos.go
@@ -25483,3 +25483,57 @@ func (c *FortiSDKClient) ReadRouterbgpNeighbor(mkey string) (mapTmp map[string]i
 	mapTmp, err = read(c, HTTPMethod, path, false)
 	return
 }
+
+// CreateRouterbgpNetwork API operation for FortiOS creates a new Network.
+// Returns the index value of the Network and execution result when the request executes successfully.
+// Returns error for service API and SDK errors.
+// See the router/bgp - network chapter in the FortiOS Handbook - CLI Reference.
+func (c *FortiSDKClient) CreateRouterbgpNetwork(params *map[string]interface{}) (output map[string]interface{}, err error) {
+
+	HTTPMethod := "POST"
+	path := "/api/v2/cmdb/router/bgp/network"
+	output = make(map[string]interface{})
+
+	err = createUpdate(c, HTTPMethod, path, params, output)
+	return
+}
+
+// UpdateRouterbgpNetwork API operation for FortiOS updates the specified Network.
+// Returns the index value of the Network and execution result when the request executes successfully.
+// Returns error for service API and SDK errors.
+// See the router/bgp - network chapter in the FortiOS Handbook - CLI Reference.
+func (c *FortiSDKClient) UpdateRouterbgpNetwork(params *map[string]interface{}, mkey string) (output map[string]interface{}, err error) {
+	HTTPMethod := "PUT"
+	path := "/api/v2/cmdb/router/bgp/network"
+	path += "/" + escapeURLString(mkey)
+	output = make(map[string]interface{})
+
+	err = createUpdate(c, HTTPMethod, path, params, output)
+	return
+}
+
+// DeleteRouterbgpNetwork API operation for FortiOS deletes the specified Network.
+// Returns error for service API and SDK errors.
+// See the router/bgp - network chapter in the FortiOS Handbook - CLI Reference.
+func (c *FortiSDKClient) DeleteRouterbgpNetwork(mkey string) (err error) {
+	HTTPMethod := "DELETE"
+	path := "/api/v2/cmdb/router/bgp/network"
+	path += "/" + escapeURLString(mkey)
+
+	err = delete(c, HTTPMethod, path)
+	return
+}
+
+// ReadRouterbgpNetwork API operation for FortiOS gets the Network
+// with the specified index value.
+// Returns the requested Network value when the request executes successfully.
+// Returns error for service API and SDK errors.
+// See the router/bgp - network chapter in the FortiOS Handbook - CLI Reference.
+func (c *FortiSDKClient) ReadRouterbgpNetwork(mkey string) (mapTmp map[string]interface{}, err error) {
+	HTTPMethod := "GET"
+	path := "/api/v2/cmdb/router/bgp/network"
+	path += "/" + escapeURLString(mkey)
+
+	mapTmp, err = read(c, HTTPMethod, path, false)
+	return
+}


### PR DESCRIPTION
Added functions for modifying bgp networks. Required to implment: https://github.com/fortinetdev/terraform-provider-fortios/pull/159