### PR TITLE
Missing PackagesFirewallPolicyBlock methods

### DIFF
--- a/fortimanager2/config/config.go
+++ b/fortimanager2/config/config.go
@@ -3,7 +3,7 @@ package config
 import (
 	"net/http"
 
-	"github.com/fortinetdev/forti-sdk-go/fortimanager2/auth"
+	"github.com/romanromanovv/forti-sdk-go/fortimanager2/auth"
 )
 
 // Config provides configuration to a FMG client instance

--- a/fortimanager2/sdkcore/forticlient.go
+++ b/fortimanager2/sdkcore/forticlient.go
@@ -6,15 +6,15 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
-	"os"
 	"net/http"
 	"net/url"
-	"strings"
+	"os"
 	"regexp"
+	"strings"
 
-	"github.com/fortinetdev/forti-sdk-go/fortimanager2/auth"
 	"github.com/fortinetdev/forti-sdk-go/fortimanager2/config"
 	"github.com/fortinetdev/forti-sdk-go/fortimanager2/request"
+	"github.com/romanromanovv/forti-sdk-go/fortimanager2/auth"
 	// "strconv"
 )
 
@@ -114,7 +114,6 @@ func login(auth *auth.Auth, c *FortiSDKClient) {
 	v2 = append(v2, paramItem)
 	data["params"] = v2
 
-
 	locJSON, err := json.Marshal(data)
 	if err != nil {
 		log.Fatal(err)
@@ -136,7 +135,6 @@ func login(auth *auth.Auth, c *FortiSDKClient) {
 		err = fmt.Errorf("cannot get response body %v", err)
 		return
 	}
-
 
 	var result map[string]interface{}
 	json.Unmarshal([]byte(string(body)), &result)
@@ -208,7 +206,7 @@ func (c *FortiSDKClient) GetDeviceVersion() (version string, err error) {
 	if err != nil {
 		return "", err
 	}
-	
+
 	if version, ok := result["result"].([]interface{})[0].(map[string]interface{})["data"].(map[string]interface{})["Version"].(string); ok {
 		regexp, err := regexp.Compile(`v([\d.]+)`)
 		match := regexp.FindStringSubmatch(version)

--- a/fortimanager2/sdkcore/sdkfos.go
+++ b/fortimanager2/sdkcore/sdkfos.go
@@ -12,8 +12,6 @@ import (
 	"fmt"
 )
 
-
-
 // UpdateDvmCmdAddDevice API operation for FortiManager updates the specified CmdAddDevice.
 // Returns the index value of the CmdAddDevice and execution result when the request executes successfully.
 // Returns error for service API and SDK errors.
@@ -20109,6 +20107,73 @@ func (c *FortiSDKClient) DeletePackagesFirewallPolicy(mkey string, paradict map[
 // See the packages - firewall policy chapter in the FortiManager Handbook - CLI Reference.
 func (c *FortiSDKClient) ReadPackagesFirewallPolicy(mkey string, paradict map[string]string) (mapTmp map[string]interface{}, err error) {
 	path := "/pm/config/[*]/pkg/{pkg}/firewall/policy"
+	path, err = replaceParaWithValue(path, paradict)
+	if err != nil {
+		return nil, fmt.Errorf("%v", err)
+	}
+
+	path += "/" + escapeURLString(mkey)
+
+	mapTmp, err = read(c, path, "get", false)
+	return
+}
+
+
+// CreatePackagesFirewallPolicy API operation for FortiManager creates a new FirewallPolicy.
+// Returns the index value of the FirewallPolicy and execution result when the request executes successfully.
+// Returns error for service API and SDK errors.
+// See the packages - firewall policy chapter in the FortiManager Handbook - CLI Reference.
+func (c *FortiSDKClient) CreatePackagesFirewallPolicyBlock(params *map[string]interface{}, paradict map[string]string) (output map[string]interface{}, err error) {
+	path := "/pm/config/[*]/pblock/{pblock}/firewall/policy"
+	path, err = replaceParaWithValue(path, paradict)
+	if err != nil {
+		return nil, fmt.Errorf("%v", err)
+	}
+
+	output, err = createUpdate(c, path, "add", params, false)
+	return
+}
+
+// UpdatePackagesFirewallPolicy API operation for FortiManager updates the specified FirewallPolicy.
+// Returns the index value of the FirewallPolicy and execution result when the request executes successfully.
+// Returns error for service API and SDK errors.
+// See the packages - firewall policy chapter in the FortiManager Handbook - CLI Reference.
+func (c *FortiSDKClient) UpdatePackagesFirewallPolicyBlock(params *map[string]interface{}, mkey string, paradict map[string]string) (output map[string]interface{}, err error) {
+	path := "/pm/config/[*]/pblock/{pblock}/firewall/policy"
+	path, err = replaceParaWithValue(path, paradict)
+	if err != nil {
+		return nil, fmt.Errorf("%v", err)
+	}
+
+	path += "/" + escapeURLString(mkey)
+
+	output, err = createUpdate(c, path, "set", params, false)
+	return
+}
+
+// DeletePackagesFirewallPolicy API operation for FortiManager deletes the specified FirewallPolicy.
+// Returns error for service API and SDK errors.
+// See the packages - firewall policy chapter in the FortiManager Handbook - CLI Reference.
+func (c *FortiSDKClient) DeletePackagesFirewallPolicyBlock(mkey string, paradict map[string]string) (err error) {
+	path := "/pm/config/[*]/pblock/{pblock}/firewall/policy"
+	path, err = replaceParaWithValue(path, paradict)
+	if err != nil {
+		return fmt.Errorf("%v", err)
+	}
+
+	path += "/" + escapeURLString(mkey)
+
+	err = delete(c, path, "delete", false)
+	return
+}
+
+// ReadPackagesFirewallPolicy API operation for FortiManager gets the FirewallPolicy
+// with the specified index value.
+// Returns the requested FirewallPolicy value when the request executes successfully.
+// Returns error for service API and SDK errors.
+// See the packages - firewall policy chapter in the FortiManager Handbook - CLI Reference.
+func (c *FortiSDKClient) ReadPackagesFirewallPolicyBlock(mkey string, paradict map[string]string) (mapTmp map[string]interface{}, err error) {
+	path := "/pm/config/[*]/pblock/{pblock}/firewall/policy"
 	path, err = replaceParaWithValue(path, paradict)
 	if err != nil {
 		return nil, fmt.Errorf("%v", err)


### PR DESCRIPTION
Hello,

This Pull Request is in reference to Support Ticket #8512414 [EFN]. It introduces modifications to the Fortinet SDK to enhance support for the Fortimanager Terraform provider, enabling the creation of policies inside the policy block.

Central to these modifications is the addition of missing functions that form the crux of this new functionality. For a detailed view of these changes, please review the updates in fortimanager2/sdkcore/sdkfos.go.

These changes aim to accommodate and streamline the process of policy creation within the policy block, deviating from the conventional policy package creation method, thus extending the flexibility and capability of the Terraform provider.

The remaining changes might appear unrelated but were essential for the compilation of a new custom provider: https://registry.terraform.io/providers/romanromanovv/fortimanager/latest. Although these alterations do not directly impact the policy block functionality, they were necessary for the broader functionality of the new custom provider.

I am open to discussing this implementation further and would appreciate your feedback. Please feel free to share your comments or questions on this matter.

Thank you for your attention and understanding.

Best Regards,
